### PR TITLE
Add palette deletion and numeric IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ You can enter the artist and album without quotes by placing a dash between
 them, e.g. ``coverpalette artist - album``. Add ``--hue`` to select colors with
 maximal hue separation. ``--light`` and ``--dark`` filter colors by brightness
 while ``--bold`` keeps the most saturated tones. ``--max-colors`` controls how
-many candidates are considered when picking an optimal palette. You can also list saved palettes with
-``coverpalette list``.  Run ``coverpalette list --pdf`` to open a PDF showing
-the stored palettes.
+many candidates are considered when picking an optimal palette. You can also
+list saved palettes with ``coverpalette list``.  Each palette is assigned a
+numeric ``id`` that is shown when listing or in the PDF generated via
+``coverpalette list --pdf``.  Palettes can be removed with
+``coverpalette delete ID``.
 
 ### API access to album covers
 Before installation, consider setting up some API keys if you so wish.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ many candidates are considered when picking an optimal palette. You can also
 list saved palettes with ``coverpalette list``.  Each palette is assigned a
 numeric ``id`` that is shown when listing or in the PDF generated via
 ``coverpalette list --pdf``.  Palettes can be removed with
-``coverpalette delete ID``.
+``coverpalette delete ID``. Palettes created before numeric ids were introduced
+will automatically be numbered when accessed.
 
 ### API access to album covers
 Before installation, consider setting up some API keys if you so wish.

--- a/USAGE.md
+++ b/USAGE.md
@@ -38,6 +38,8 @@ Each entry is shown with a numeric ``id`` which can be used to load or delete
 palettes.  Add ``--pdf`` to generate a PDF that displays every palette with a
 horizontal color bar. The PDF is stored under
 ``~/.covers2colors/palettes/palettes.pdf``.
+Palettes created before numeric ids were introduced will automatically be
+numbered the next time they are listed or loaded.
 
 To remove a saved palette use:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,8 +34,16 @@ To list previously saved palettes run:
 coverpalette list
 ```
 
-Add ``--pdf`` to generate a PDF that displays every palette with a horizontal
-color bar. The PDF is stored under ``~/.covers2colors/palettes/palettes.pdf``.
+Each entry is shown with a numeric ``id`` which can be used to load or delete
+palettes.  Add ``--pdf`` to generate a PDF that displays every palette with a
+horizontal color bar. The PDF is stored under
+``~/.covers2colors/palettes/palettes.pdf``.
+
+To remove a saved palette use:
+
+```bash
+coverpalette delete ID
+```
 
 ## Python
 

--- a/covers2colors/cli.py
+++ b/covers2colors/cli.py
@@ -42,10 +42,25 @@ def main() -> None:
             print("No saved palettes found")
             return
         for entry in entries:
-            name = entry.get("name")
+            pid = entry.get("id")
+            artist = entry.get("artist")
+            album = entry.get("album")
             n = entry.get("n_colors")
             path = entry.get("path")
-            print(f"{name} ({n} colors) - {path}")
+            print(f"#{pid}: {artist} - {album} ({n} colors) - {path}")
+        return
+
+    if len(sys.argv) > 1 and sys.argv[1] == "delete":
+        del_parser = argparse.ArgumentParser(
+            prog="coverpalette delete", description="Delete a saved palette"
+        )
+        del_parser.add_argument("id", type=int, help="Palette id to delete")
+        args = del_parser.parse_args(sys.argv[2:])
+
+        if CoverPalette.delete_palette(args.id):
+            print(f"Deleted palette {args.id}")
+        else:
+            print(f"Palette {args.id} not found")
         return
 
     # Support an unquoted "artist - album" form by rewriting sys.argv
@@ -121,14 +136,14 @@ def main() -> None:
     print("Color-blind friendly:", palette.is_colorblind_friendly)
 
     if args.save:
-        palette.save_palette()
-        print("Palette saved")
+        pid = palette.save_palette()
+        print(f"Palette saved as #{pid}")
     else:
         palette.preview_palette(cmap)
         ans = input("Save this palette? [y/N] ").strip().lower()
         if ans in {"y", "yes"}:
-            palette.save_palette()
-            print("Palette saved")
+            pid = palette.save_palette()
+            print(f"Palette saved as #{pid}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- assign numeric IDs to saved palettes
- list palettes with IDs and add delete command
- allow palette deletion via API
- update PDF output to include numeric IDs
- document new features

## Testing
- `pytest -q`
- `python -m covers2colors.cli list` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68471e7c8d4c83238e761c68e2992f4c